### PR TITLE
Added keyswitch event convenience functions

### DIFF
--- a/src/kaleidoglyph/Controller.h
+++ b/src/kaleidoglyph/Controller.h
@@ -87,13 +87,13 @@ inline Key Controller::lookup(KeyAddr k) const {
 }
 
 inline
-void pressKeyswitch(KeyAddr k, Plugin* caller) {
+void Controller::pressKeyswitch(KeyAddr k, Plugin* caller) {
   KeyswitchEvent event{k, cKeyswitchState::pressed};
   handleKeyswitchEvent(event, caller);
 }
 
 inline
-void releaseKeyswitch(KeyAddr k, Plugin* caller) {
+void Controller::releaseKeyswitch(KeyAddr k, Plugin* caller) {
   KeyswitchEvent event{k, cKeyswitchState::released};
   handleKeyswitchEvent(event, caller);
 }

--- a/src/kaleidoglyph/Controller.h
+++ b/src/kaleidoglyph/Controller.h
@@ -52,6 +52,8 @@ class Controller {
   static constexpr byte id{0xFF};
 
   void handleKeyswitchEvent(KeyswitchEvent event, Plugin* caller = nullptr);
+  void pressKeyswitch(KeyAddr k, Plugin* caller = nullptr);
+  void releaseKeyswitch(KeyAddr k, Plugin* caller = nullptr);
   void sendKeyboardReport();
 
   Key lookup(KeyAddr key_addr) const; // probably pointless
@@ -84,5 +86,16 @@ inline Key Controller::lookup(KeyAddr k) const {
   return keymap_[k];
 }
 
+inline
+void pressKeyswitch(KeyAddr k, Plugin* caller) {
+  KeyswitchEvent event{k, cKeyswitchState::pressed};
+  handleKeyswitchEvent(event, caller);
+}
+
+inline
+void releaseKeyswitch(KeyAddr k, Plugin* caller) {
+  KeyswitchEvent event{k, cKeyswitchState::released};
+  handleKeyswitchEvent(event, caller);
+}
 
 } // namespace kaleidoglyph {

--- a/src/kaleidoglyph/KeyswitchEvent.h
+++ b/src/kaleidoglyph/KeyswitchEvent.h
@@ -6,6 +6,7 @@
 #include KALEIDOGLYPH_KEYADDR_H
 
 #include "kaleidoglyph/Key.h"
+#include "kaleidoglyph/cKey.h"
 #include "kaleidoglyph/KeyswitchState.h"
 
 
@@ -18,7 +19,8 @@ struct KeyswitchEvent {
   KeyswitchState  state;
 
   KeyswitchEvent() {}
-  KeyswitchEvent(Key _key, KeyAddr _addr, KeyswitchState _state)
+
+  KeyswitchEvent(KeyAddr _addr, KeyswitchState _state, Key _key = cKey::clear)
     : key(_key), addr(_addr), state(_state) {}
 
 };


### PR DESCRIPTION
To make client code simpler and more reliable, I added two convenience functions to the `Controller` class: `pressKeyswitch()` & `releaseKeyswitch()`. These are thin wrappers around `handleKeyswitchEvent()` that don't require construction of a `KeyswitchEvent` object, but just take a `KeyAddr` as an argument (and, optionally a `Plugin* caller`).