### PR TITLE
Rename KeyswitchEvent & KeyswitchState structures

### DIFF
--- a/src/kaleidoglyph/Controller.cpp
+++ b/src/kaleidoglyph/Controller.cpp
@@ -42,7 +42,7 @@ void Controller::run() {
 void Controller::handleKeyswitchEvent(KeyswitchEvent event, Plugin* caller) {
 
   const KeyAddr& k = event.addr;
-  const KeyswitchState& state = event.state;
+  const KeyState& state = event.state;
 
   if (active_keys_[k] == cKey::masked) {
     if (state.toggledOff())

--- a/src/kaleidoglyph/Controller.cpp
+++ b/src/kaleidoglyph/Controller.cpp
@@ -8,7 +8,7 @@
 #include KALEIDOGLYPH_HARDWARE_KEYBOARD_H
 #include "kaleidoglyph/hid/Report.h"
 #include "kaleidoglyph/hooks.h"
-#include "kaleidoglyph/KeyswitchEvent.h"
+#include "kaleidoglyph/KeyEvent.h"
 #include "kaleidoglyph/cKey.h"
 #include "kaleidoglyph/Key.h"
 
@@ -32,14 +32,14 @@ void Controller::run() {
 
   keyboard_.scanMatrix();
 
-  for (KeyswitchEvent event : keyboard_) {
-    handleKeyswitchEvent(event);
+  for (KeyEvent event : keyboard_) {
+    handleKeyEvent(event);
   }
 }
 
 // I'm starting to think that we should just call the sendReport* functions from here,
 // rather than scattering the code around
-void Controller::handleKeyswitchEvent(KeyswitchEvent event, Plugin* caller) {
+void Controller::handleKeyEvent(KeyEvent event, Plugin* caller) {
 
   const KeyAddr& k = event.addr;
   const KeyState& state = event.state;

--- a/src/kaleidoglyph/Controller.h
+++ b/src/kaleidoglyph/Controller.h
@@ -20,7 +20,7 @@
 #include KALEIDOGLYPH_HARDWARE_KEYBOARD_H
 #include KALEIDOGLYPH_KEYADDR_H
 #include "kaleidoglyph/Keymap.h"
-#include "kaleidoglyph/KeyswitchEvent.h"
+#include "kaleidoglyph/KeyEvent.h"
 #include "kaleidoglyph/Layer.h"
 #include "kaleidoglyph/cKey.h"
 #include "kaleidoglyph/Plugin.h"
@@ -54,7 +54,7 @@ class Controller {
 
   static constexpr byte id{0xFF};
 
-  void handleKeyswitchEvent(KeyswitchEvent event, Plugin* caller = nullptr);
+  void handleKeyEvent(KeyEvent event, Plugin* caller = nullptr);
   void pressKeyswitch(KeyAddr k, Plugin* caller = nullptr);
   void releaseKeyswitch(KeyAddr k, Plugin* caller = nullptr);
   void sendKeyboardReport();
@@ -92,14 +92,14 @@ Key Controller::lookup(KeyAddr k) const {
 
 inline
 void Controller::pressKeyswitch(KeyAddr k, Plugin* caller) {
-  KeyswitchEvent event{k, cKeyState::pressed};
-  handleKeyswitchEvent(event, caller);
+  KeyEvent event{k, cKeyState::pressed};
+  handleKeyEvent(event, caller);
 }
 
 inline
 void Controller::releaseKeyswitch(KeyAddr k, Plugin* caller) {
-  KeyswitchEvent event{k, cKeyState::released};
-  handleKeyswitchEvent(event, caller);
+  KeyEvent event{k, cKeyState::released};
+  handleKeyEvent(event, caller);
 }
 
 } // namespace kaleidoglyph {

--- a/src/kaleidoglyph/Controller.h
+++ b/src/kaleidoglyph/Controller.h
@@ -92,13 +92,13 @@ Key Controller::lookup(KeyAddr k) const {
 
 inline
 void Controller::pressKeyswitch(KeyAddr k, Plugin* caller) {
-  KeyswitchEvent event{k, cKeyswitchState::pressed};
+  KeyswitchEvent event{k, cKeyState::pressed};
   handleKeyswitchEvent(event, caller);
 }
 
 inline
 void Controller::releaseKeyswitch(KeyAddr k, Plugin* caller) {
-  KeyswitchEvent event{k, cKeyswitchState::released};
+  KeyswitchEvent event{k, cKeyState::released};
   handleKeyswitchEvent(event, caller);
 }
 

--- a/src/kaleidoglyph/KeyEvent.h
+++ b/src/kaleidoglyph/KeyEvent.h
@@ -12,15 +12,15 @@
 
 namespace kaleidoglyph {
 
-struct KeyswitchEvent {
+struct KeyEvent {
 
   Key       key;
   KeyAddr   addr;
   KeyState  state;
 
-  KeyswitchEvent() {}
+  KeyEvent() {}
 
-  KeyswitchEvent(KeyAddr _addr, KeyState _state, Key _key = cKey::clear)
+  KeyEvent(KeyAddr _addr, KeyState _state, Key _key = cKey::clear)
     : key(_key), addr(_addr), state(_state) {}
 
 };

--- a/src/kaleidoglyph/KeyState.h
+++ b/src/kaleidoglyph/KeyState.h
@@ -7,20 +7,20 @@
 
 namespace kaleidoglyph {
 
-class KeyswitchState {
+class KeyState {
 
  public:
 
   constexpr
-  KeyswitchState() : raw_(0) {}
+  KeyState() : raw_(0) {}
 
   // Constructor sets all reserved bits to zero.
   explicit constexpr
-  KeyswitchState(byte state)
+  KeyState(byte state)
     : raw_(state & 0x03) {}
 
   constexpr
-  KeyswitchState(bool curr, bool prev)
+  KeyState(bool curr, bool prev)
     : raw_(curr | (prev << 1)) {}
 
   // These comparisons all assume that the reserved bits are all zero.
@@ -68,15 +68,15 @@ class KeyswitchState {
 
 };
 
-namespace cKeyswitchState {
+namespace cKeyState {
 
-constexpr KeyswitchState inactive (0);
-constexpr KeyswitchState pressed  (1);
-constexpr KeyswitchState released (2);
-constexpr KeyswitchState held     (3);
+constexpr KeyState inactive (0);
+constexpr KeyState pressed  (1);
+constexpr KeyState released (2);
+constexpr KeyState held     (3);
 
-constexpr KeyswitchState idle = inactive;
+constexpr KeyState idle = inactive;
 
-} // namespace cKeyswitchState {
+} // namespace cKeyState {
 
 } // namespace kaleidoglyph {

--- a/src/kaleidoglyph/Keymap.cpp
+++ b/src/kaleidoglyph/Keymap.cpp
@@ -98,7 +98,7 @@ void Keymap::toggleLayer(byte layer_index) {
 }
 
 
-void Keymap::handleLayerChange(KeyswitchEvent event, KeyArray& active_keys) {
+void Keymap::handleLayerChange(KeyEvent event, KeyArray& active_keys) {
   LayerKey layer_key{event.key};
 
   assert(layer_key.index() < layer_count_);

--- a/src/kaleidoglyph/Keymap.h
+++ b/src/kaleidoglyph/Keymap.h
@@ -11,7 +11,7 @@
 #include "kaleidoglyph/KeymapEntry.h"
 #include "kaleidoglyph/Layer.h"
 #include "kaleidoglyph/cKeyAddr.h"
-#include "kaleidoglyph/KeyswitchEvent.h"
+#include "kaleidoglyph/KeyEvent.h"
 #include "kaleidoglyph/KeyArray.h"
 
 
@@ -55,7 +55,7 @@ class Keymap {
   void shiftToLayer(byte layer_index);
   void moveToLayer(byte layer_index);
 
-  void handleLayerChange(KeyswitchEvent event, KeyArray& active_keys);
+  void handleLayerChange(KeyEvent event, KeyArray& active_keys);
 
   Key operator[](KeyAddr key_addr) const;
 

--- a/src/kaleidoglyph/KeyswitchEvent.h
+++ b/src/kaleidoglyph/KeyswitchEvent.h
@@ -7,20 +7,20 @@
 
 #include "kaleidoglyph/Key.h"
 #include "kaleidoglyph/cKey.h"
-#include "kaleidoglyph/KeyswitchState.h"
+#include "kaleidoglyph/KeyState.h"
 
 
 namespace kaleidoglyph {
 
 struct KeyswitchEvent {
 
-  Key             key;
-  KeyAddr         addr;
-  KeyswitchState  state;
+  Key       key;
+  KeyAddr   addr;
+  KeyState  state;
 
   KeyswitchEvent() {}
 
-  KeyswitchEvent(KeyAddr _addr, KeyswitchState _state, Key _key = cKey::clear)
+  KeyswitchEvent(KeyAddr _addr, KeyState _state, Key _key = cKey::clear)
     : key(_key), addr(_addr), state(_state) {}
 
 };

--- a/src/kaleidoglyph/Plugin.h
+++ b/src/kaleidoglyph/Plugin.h
@@ -4,7 +4,7 @@
 
 #include <Arduino.h>
 
-#include "kaleidoglyph/KeyswitchEvent.h"
+#include "kaleidoglyph/KeyEvent.h"
 #include "kaleidoglyph/KeyArray.h"
 #include "kaleidoglyph/hid/Report.h"
 
@@ -18,7 +18,7 @@ class Plugin {
   virtual void preScanHook(uint16_t current_time) {}
 
   // I might decide to break this up into multiple hooks
-  virtual bool keyswitchEventHook(KeyswitchEvent& event, Plugin*& caller) {
+  virtual bool keyswitchEventHook(KeyEvent& event, Plugin*& caller) {
     return true;
   }
 
@@ -28,7 +28,7 @@ class Plugin {
   }
 
   // Should probably be renamed postKeyboardReportHook()
-  virtual void postReportHook(KeyswitchEvent event) {}
+  virtual void postReportHook(KeyEvent event) {}
   
  protected:
 

--- a/src/kaleidoglyph/hooks.cpp
+++ b/src/kaleidoglyph/hooks.cpp
@@ -7,7 +7,7 @@
 // I think it will work to put "hooks.cpp" in the sketch module, with the *.ino file.
 
 #include "kaleidoglyph/hooks.h"
-#include "kaleidoglyph/KeyswitchEvent.h"
+#include "kaleidoglyph/KeyEvent.h"
 #include "kaleidoglyph/KeyArray.h"
 #include "kaleidoglyph/hid/Report.h"
 
@@ -24,7 +24,7 @@ void preScanHooks() {}
 /// Return true if processing should continue, false if the event has been completely
 /// handled, and no further action should take place in response to the event.
 __attribute__((weak))
-bool keyswitchEventHooks(KeyswitchEvent& event, KeyArray& active_keys, Plugin*& caller) {
+bool keyswitchEventHooks(KeyEvent& event, KeyArray& active_keys, Plugin*& caller) {
   return true;
 }
 
@@ -36,7 +36,7 @@ bool preKeyboardReportHooks(hid::keyboard::Report& keyboard_report) {
 
 /// Call keyboard HID post-report hooks (run after a keyboard HID report is sent)
 __attribute__((weak))
-void postKeyboardReportHooks(KeyswitchEvent event) {}
+void postKeyboardReportHooks(KeyEvent event) {}
 
 } // namespace hooks {
 } // namespace kaleidoglyph {

--- a/src/kaleidoglyph/hooks.h
+++ b/src/kaleidoglyph/hooks.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "kaleidoglyph/KeyswitchEvent.h"
+#include "kaleidoglyph/KeyEvent.h"
 #include "kaleidoglyph/KeyArray.h"
 #include "kaleidoglyph/Plugin.h"
 #include "kaleidoglyph/hid/Report.h"
@@ -21,13 +21,13 @@ namespace hooks {
 void preScanHooks();
 
 /// Call keyswitch event handler hooks (run when a key press or release is detected)
-bool keyswitchEventHooks(KeyswitchEvent& event, KeyArray& active_keys, Plugin*& caller);
+bool keyswitchEventHooks(KeyEvent& event, KeyArray& active_keys, Plugin*& caller);
 
 /// Call keyboard HID pre-report hooks (run when a keyboard HID report is about to be sent)
 bool preKeyboardReportHooks(hid::keyboard::Report& keyboard_report);
 
 /// Call keyboard HID post-report hooks (run after a keyboard HID report is sent)
-void postKeyboardReportHooks(KeyswitchEvent event);
+void postKeyboardReportHooks(KeyEvent event);
 
 } // namespace hooks {
 } // namespace kaleidoglyph {


### PR DESCRIPTION
I'm trying to make a distinction between events that are physical-only (`Keyswitch*`) and the more general events that can be software-only (`Key*`), in advance of changing the hooks available in the event handler loop.