### PR TITLE
LED modes with separate updaters

### DIFF
--- a/src/kaleidoglyph/hooks.h
+++ b/src/kaleidoglyph/hooks.h
@@ -30,7 +30,7 @@ void preKeyswitchScan();
 void setLedForeground(KeyAddr k);
 
 /// Restore foreground LED colors
-bool setForegroundColor(KeyAddr k, LedController& led_controller);
+bool setForegroundColor(KeyAddr k);
 
 /// Call keyswitch event handler hooks (run when a key press or release is detected)
 EventHandlerResult onKeyswitchEvent(KeyEvent& event);

--- a/src/kaleidoglyph/led/Array.h
+++ b/src/kaleidoglyph/led/Array.h
@@ -1,0 +1,18 @@
+// -*- c++ -*-
+
+#pragma once
+
+#include <Arduino.h>
+
+namespace kaleidoglyph {
+
+template<typename _Type, byte _size>
+class ConstArray {
+ public:
+  ConstArray(_Type (&)) {}
+  byte size() { return _size; }
+ private:
+  _Type const array_[_size];
+};
+
+} //

--- a/src/kaleidoglyph/led/Breathe.h
+++ b/src/kaleidoglyph/led/Breathe.h
@@ -7,34 +7,40 @@
 #include <kaleidoglyph/KeyAddr.h>
 #include <kaleidoglyph/Color.h>
 #include <kaleidoglyph/led/utils.h>
+#include "kaleidoglyph/led/LedMode.h"
 
 
 namespace kaleidoglyph {
-//namespace led {
 
-// Forward declaration; we can't include the header
-class LedController;
-
-class LedBreatheMode : public LedBackgroundMode {
+class LedBreatheMode : public LedMode {
 
  public:
-
   LedBreatheMode(byte hue = 170) : hue_(hue) {}
 
-  void update(LedController& led_controller) override;
-
+  byte getHue() const { return hue_; }
   void setHue(byte hue) { hue_ = hue; }
 
- private:
+  // The itinerant Updater class is what does the actual work
+  class Updater : public LedModeUpdater {
+   private:
+    LedBreatheMode& mode_;
 
+   public:
+    Updater(LedBreatheMode& mode) : mode_(mode) {}
+    void update() override;
+   private:
+    byte getHue() const { return mode_.getHue(); }
+  };
+
+ private:
   byte hue_;
 
 };
 
 inline
-void LedBreatheMode::update(LedController& led_controller) {
-  Color color = breathCompute(hue_);
-  led_controller.setKeyColor(color);
+void LedBreatheMode::Updater::update() {
+  Color color = breathCompute(mode_.getHue());
+  LedMode::manager().setKeyColor(color);
 }
 
 //} // namespace led {

--- a/src/kaleidoglyph/led/LedBackgroundMode.h
+++ b/src/kaleidoglyph/led/LedBackgroundMode.h
@@ -14,13 +14,27 @@ class LedController;
 
 class LedBackgroundMode : public Plugin {
 
+  friend class LedController;
+
  public:
-  virtual void activate(LedController&) {}
-  virtual void update(LedController&) {}
-  virtual Color getKeyColor(KeyAddr /*k*/) const {
-    return Color{0, 0, 0};
+
+ protected:
+  bool isActive() const {
+    assert(led_controller_p_ != nullptr);
+    return (this->id_ == led_controller_p_->activeModeIndex());
+  }
+  static LedController& controller() const {
+    return *led_controller_p_;
   }
 
+ private:
+  static LedController* led_controller_p_;
+  static void initializeController(LedController* led_controller_p) {
+    assert(led_controller_p_ == nullptr);
+    led_controller_p_ = led_controller_p;
+  }
+  byte id_;
+  void assignId(byte id) { id_ = id; }
 };
 
 } // namespace kaleidoglyph {

--- a/src/kaleidoglyph/led/LedController.cpp
+++ b/src/kaleidoglyph/led/LedController.cpp
@@ -41,9 +41,7 @@ void LedManager::setForeground(KeyAddr k) {
 }
 
 void LedManager::clearBackgroundColors() {
-  for (KeyAddr k : KeyAddr::Iterator{}) {
-    setKeyColor(k, Color{0, 0, 0});
-  }
+  setKeyColor(Color{0, 0, 0});
 }
 
 void LedManager::activateBackgroundMode() {
@@ -62,6 +60,8 @@ void LedManager::activateBackgroundMode() {
     loader.loadUpdater(curr_mode_p_, updater_p_);
     // activate current led mode
     updater_p_->activate();
+  } else {
+    clearBackgroundColors();
   }
 }
 

--- a/src/kaleidoglyph/led/LedController.cpp
+++ b/src/kaleidoglyph/led/LedController.cpp
@@ -1,0 +1,136 @@
+// -*- c++ -*-
+
+#include "kaleidoglyph/led/LedController.h"
+
+namespace kaleidoglyph {
+
+// Possibly useful to LED modes
+Color LedManager::getKeyColor(KeyAddr k) const {
+  return keyboard_.getKeyColor(k);
+}
+
+// Set the color of a key. It will get updated on the next LED update.
+void LedManager::setKeyColor(KeyAddr k, Color color) {
+  keyboard_.setKeyColor(k, color);
+}
+
+// Set the color of an LED directly. This will be needed for LEDs not associated
+// with individual keys.
+void LedManager::setLedColor(LedAddr led, Color color) {
+  keyboard_.setLedColor(led, color);
+}
+
+// Set the color of all keys
+void LedManager::setKeyColor(Color color) {
+  for (KeyAddr k : KeyAddr::Iterator{}) {
+    setKeyColor(k, color);
+  }
+}
+
+// When LED modes change, all we do is set this index; the actual mode change
+// takes place in sync with the LED update cycle.
+void LedManager::setActiveMode(byte index) {
+  next_mode_index_ = index;
+}
+
+// A plugin can call this function to signal that it will override the
+// background LED mode before the next update. It doesn't set the LED at that
+// time, because it needs to repeatedly override the background LED mode anyway.
+void LedManager::setForeground(KeyAddr k) {
+  foreground_mask_.set(k);
+}
+
+void LedManager::clearBackgroundColors() {
+  for (KeyAddr k : KeyAddr::Iterator{}) {
+    setKeyColor(k, Color{0, 0, 0});
+  }
+}
+
+void LedManager::activateBackgroundMode() {
+  // This function needs to be the place where the active LED mode gets swapped
+  // out for a new one from the list in PROGMEM. Note: we don't clear the
+  // existing colors here; the new mode is responsible for doing so itself.
+  if (isValidMode(curr_mode_index_)) {
+    // read loader from progmem
+    LedModeLoader loader =
+        readFromProgmem(pgm_updater_loaders_[curr_mode_index_]);
+    // set current mode pointer. I'm not sure we actually need this for
+    // anything.
+    curr_mode_p_ = loader.led_mode_p;
+    // load current mode's updater. This replaces the previous updater, so now
+    // `updater_p_` is a pointer to the new curent mode's updater.
+    loader.loadUpdater(curr_mode_p_, updater_p_);
+    // activate current led mode
+    updater_p_->activate();
+  }
+}
+
+void LedManager::updateBackgroundColors() {
+  if (isValidMode(curr_mode_index_)) {
+    updater_p_->update();
+  }
+}
+
+void LedManager::preKeyswitchScan() {
+  static byte last_sync_time{0};
+  static bool sync_in_progress{false};
+  static bool sync_complete{false};
+
+  if (sync_in_progress) {
+    if (sync_complete) {
+      if (next_mode_index_ != curr_mode_index_) {
+        curr_mode_index_ = next_mode_index_;
+        activateBackgroundMode();
+      } else {
+        updateBackgroundColors();
+      }
+      sync_in_progress = false;
+      sync_complete    = false;
+      return;
+    }
+    sync_complete = keyboard_.syncLeds();
+    return;
+  }
+
+  byte current_time = Controller::scanStartTime();
+  byte elapsed_time = current_time - last_sync_time;
+  if (elapsed_time > led_sync_interval) {
+    restoreForegroundColors();
+    sync_in_progress = true;
+    last_sync_time   = current_time;
+  }
+}
+
+void LedManager::restoreForegroundColors() {
+  for (KeyAddr k : foreground_mask_) {
+    bool masked = hooks::setForegroundColor(k);
+    // a plugin's `setForegroundColor()` function will call
+    // `led_manager->setKeyColor()` and return `true`, or it will return
+    // `false`, and the next plugin will get called.
+    if (!masked) {
+      foreground_mask_.clear(k);
+      restoreBackgroundColor(k);
+    }
+  }
+}
+
+// Called when a foreground override comes to an end, and we need to restore the
+// color of an LED based on the current mode.
+void LedManager::restoreBackgroundColor(KeyAddr k) {
+  if (isValidMode(curr_mode_index_)) {
+    updater_p_->restore(k);
+  } else {
+    setKeyColor(k, Color{0, 0, 0});
+  }
+}
+
+EventHandlerResult LedManager::onKeyEvent(KeyEvent& event) {
+  if (event.state.toggledOn()) {
+    if (event.key == cLedKey::next_mode) {
+      nextMode();
+    }
+  }
+  return EventHandlerResult::proceed;
+}
+
+}  // namespace kaleidoglyph

--- a/src/kaleidoglyph/led/LedController.h
+++ b/src/kaleidoglyph/led/LedController.h
@@ -4,222 +4,108 @@
 
 #include <Arduino.h>
 
-#include "kaleidoglyph/hardware/Keyboard.h"
-#include "kaleidoglyph/KeyAddr.h"
 #include "kaleidoglyph/Color.h"
+#include "kaleidoglyph/KeyAddr.h"
 #include "kaleidoglyph/KeyAddrBitfield.h"
-#include "kaleidoglyph/led/LedBackgroundMode.h"
-#include "kaleidoglyph/utils.h"
+#include "kaleidoglyph/hardware/Keyboard.h"
 #include "kaleidoglyph/hooks.h"
+#include "kaleidoglyph/led/LedMode.h"
+#include "kaleidoglyph/utils.h"
 
 
 namespace kaleidoglyph {
 
-#if defined(LED_CONTROLLER_CONSTANTS_H)
-#include LED_CONTROLLER_CONSTANTS_H
+#if defined(KALEIDOGLYPH_LED_MANAGER_CONSTANTS_H)
+#include KALEIDOGLYPH_LED_MANAGER_CONSTANTS_H
 #else
+// I should make this a member variable, not a constant (different modes should
+// use different update intervals)
 constexpr byte led_sync_interval{32};
 #endif
 
-class LedController {
+class LedManager {
 
  public:
-  template<byte _modes_count>
-  LedController(LedBackgroundMode* const (&modes)[_modes_count],
-                Controller& controller,
-                hardware::Keyboard& keyboard)
-      : controller_(controller),
-        keyboard_(keyboard),
-        modes_(modes),
-        modes_count_(_modes_count) {}
+  // This constructor is a template function so that we can just pass an array
+  // to it, instead of needing to have the size of the array as an additional
+  // parameter. The first parameter is an array of `LedModeUpdaterLoader`s (in
+  // PROGMEM), which contain pointers to ...
+  template <byte _modes_count>
+  LedManager(LedModeLoader const (&pgm_loaders)[_modes_count],
+             void*               updater_buffer,
+             hardware::Keyboard& keyboard)
+      : keyboard_(keyboard),
+        pgm_updater_loaders_(pgm_loaders),
+        modes_count_(_modes_count),
+        updater_p_(static_cast<LedModeUpdater*>(updater_buffer)) {
+    LedMode::init(this);
+    for (byte i{0}; i < _modes_count; ++i) {
+      LedModeLoader loader = readFromProgmemArray(pgm_loaders, i);
+      loader.led_mode_p->assignId(i);
+    }
+  }
 
-  // Note we don't provied LedAddr versions of these, because that makes the overrides
-  // overly complex.
+  // Note we don't provied LedAddr versions of these, because that makes the
+  // overrides overly complex.
   Color getKeyColor(KeyAddr k) const;
-  void setKeyColor(KeyAddr k, Color color);
-  void setKeyColor(Color color);
-  void setLedColor(LedAddr led, Color color);
+  void  setKeyColor(KeyAddr k, Color color);
+  void  setKeyColor(Color color);
+  void  setLedColor(LedAddr led, Color color);
 
-  void preKeyswitchScan();
+  void               preKeyswitchScan();
   EventHandlerResult onKeyEvent(KeyEvent& event);
-  
+
   void setForeground(KeyAddr k);
+
+  byte activeModeIndex() const { return curr_mode_index_; }
 
   void nextMode() {
     next_mode_index_ = curr_mode_index_ + 1;
-    if (next_mode_index_ > modes_count_)
-      next_mode_index_ = 0;
+    if (next_mode_index_ > modes_count_) next_mode_index_ = 0;
   }
-  void backgroundOff() {
-    next_mode_index_ = 0xFF;
-  }
+  void backgroundOff() { next_mode_index_ = 0xFF; }
 
-  LedBackgroundMode& getCurrentMode() const;
-  void setActiveMode(byte index);
+  LedMode* getCurrentMode() const;
+  void     setActiveMode(byte index);
+
+  // byte requestInterval(byte interval);
 
   // We need a hook somewhere for layer changes (see LED-ActiveLayerColor.cpp)
+  // ???
 
 
  private:
-
   static constexpr byte invalid_index_{0xFF};
 
-  Controller& controller_;
   hardware::Keyboard& keyboard_;
 
-  LedBackgroundMode* const *modes_;
-  byte               const  modes_count_;
+  LedModeLoader const* pgm_updater_loaders_;
+  byte const           modes_count_;
+
+  LedModeUpdater* const updater_p_;
+  LedMode*              curr_mode_p_;
 
   byte curr_mode_index_{invalid_index_};
   byte next_mode_index_{invalid_index_};
 
-  //LedMode* active_mode_{nullptr};
+  // LedMode* active_mode_{nullptr};
 
   KeyAddrBitfield foreground_mask_;
 
   void restoreForegroundColors();
   void restoreBackgroundColor(KeyAddr k);
-  
+
   void activateBackgroundMode();
   void updateBackgroundColors();
   void clearBackgroundColors();
 
-  bool isValidMode(byte index) {
-    return (index < modes_count_);
-  }
-
+  bool isValidMode(byte index) { return (index < modes_count_); }
 };
 
-// Possibly useful to LED modes
-inline
-Color LedController::getKeyColor(KeyAddr k) const {
-  return keyboard_.getKeyColor(k);
-}
+// There are a whole lot of functions defined here that would be better to
+// define in a non-header file, but I want most of them to be inlined in the
+// files where they're called from, and I'm not sure that will happen if the
+// linker is involved.
 
-// Set the color of a key. It will get updated on the next LED update.
-inline
-void LedController::setKeyColor(KeyAddr k, Color color) {
-  keyboard_.setKeyColor(k, color);
-}
 
-inline
-void LedController::setLedColor(LedAddr led, Color color) {
-  keyboard_.setLedColor(led, color);
-}
-
-inline
-void LedController::setKeyColor(Color color) {
-  for (KeyAddr k{cKeyAddr::start}; k < cKeyAddr::end; ++k) {
-    setKeyColor(k, color);
-  }
-}
-
-inline
-LedBackgroundMode& LedController::getCurrentMode() const {
-  return *(readPointerFromProgmemArrayPtr(modes_, curr_mode_index_));
-}
-
-// When LED modes change, all we do is set this index; the actual mode change takes place
-// in sync with the LED update cycle.
-inline
-void LedController::setActiveMode(byte index) {
-  next_mode_index_ = index;
-}
-
-// A plugin can call this function to signal that it will override the background LED mode
-// before the next update. It doesn't set the LED at that time, because it needs to
-// repeatedly override the background LED mode anyway.
-inline
-void LedController::setForeground(KeyAddr k) {
-  foreground_mask_.set(k);
-}
-
-inline
-void LedController::restoreBackgroundColor(KeyAddr k) {
-  foreground_mask_.clear(k);
-  if (isValidMode(curr_mode_index_)) {
-    Color color = getCurrentMode().getKeyColor(k);
-    setKeyColor(k, color);
-  } else {
-    setKeyColor(k, Color{0, 0, 0});
-  }
-}
-
-inline
-void LedController::clearBackgroundColors() {
-  for (KeyAddr k{cKeyAddr::start}; k < cKeyAddr::end; ++k) {
-    setKeyColor(k, Color{0, 0, 0});
-  }
-}
-
-inline
-void LedController::activateBackgroundMode() {
-  clearBackgroundColors();
-  if (isValidMode(curr_mode_index_)) {
-    getCurrentMode().activate(*this);
-  }
-}
-
-inline
-void LedController::updateBackgroundColors() {
-  if (isValidMode(curr_mode_index_)) {
-    getCurrentMode().update(*this);
-  }
-}
-
-inline
-void LedController::preKeyswitchScan() {
-  static byte last_sync_time{0};
-  static bool sync_in_progress{false};
-  static bool sync_complete{false};
-
-  if (sync_in_progress) {
-    if (sync_complete) {
-      if (next_mode_index_ != curr_mode_index_) {
-        curr_mode_index_ = next_mode_index_;
-        activateBackgroundMode();
-      } else {
-        updateBackgroundColors();
-      }
-      sync_in_progress = false;
-      sync_complete = false;
-      return;
-    }
-    sync_complete = keyboard_.syncLeds();
-    return;
-  }
-
-  // This is the only thing we need the Controller reference for. It's a run-time only
-  // thing, and I'd like to get rid of that initialization order dependency, without
-  // resorting to global singletons.
-  byte current_time = Controller::scanStartTime();
-  byte elapsed_time = current_time - last_sync_time;
-  if (elapsed_time > led_sync_interval) {
-    restoreForegroundColors();
-    sync_in_progress = true;
-    last_sync_time = current_time;
-  }
-}
-
-inline
-void LedController::restoreForegroundColors() {
-  for (KeyAddr k : foreground_mask_) {
-    bool masked = hooks::setForegroundColor(k, *this);
-    // a plugin's `setForegroundColor()` function will call
-    // `led_controller->setKeyColor()` and return `true`, or return `false`.
-    if (! masked)
-      restoreBackgroundColor(k);
-  }
-}
-
-inline
-EventHandlerResult LedController::onKeyEvent(KeyEvent& event) {
-  if (event.state.toggledOn()) {
-    if (event.key == cLedKey::next_mode) {
-      nextMode();
-    }
-  }
-  return EventHandlerResult::proceed;
-}
-
-} // namespace kaleidoglyph {
+}  // namespace kaleidoglyph

--- a/src/kaleidoglyph/led/LedMode.cpp
+++ b/src/kaleidoglyph/led/LedMode.cpp
@@ -1,0 +1,26 @@
+// -*- c++ -*-
+
+#include "kaleidoglyph/led/LedMode.h"
+#include "kaleidoglyph/led/LedController.h"
+
+namespace kaleidoglyph {
+
+// Temporary initialization of LedController pointer. This gets set when the
+// LedController object is created, via `initializeController()`.
+LedManager* LedMode::led_manager_p_{nullptr};
+
+LedManager& LedMode::manager() {
+  return *led_manager_p_;
+}
+
+void LedMode::init(LedManager* led_manager_p) {
+  assert(led_manager_p_ == nullptr);
+  led_manager_p_ = led_manager_p;
+}
+
+bool LedMode::isActive() const {
+  assert(led_manager_p_ != nullptr);
+  return (this->id_ == led_manager_p_->activeModeIndex());
+}
+
+}  // namespace kaleidoglyph

--- a/src/kaleidoglyph/led/LedMode.h
+++ b/src/kaleidoglyph/led/LedMode.h
@@ -1,0 +1,158 @@
+// -*- c++ -*-
+
+#pragma once
+
+#include <Kaleidoglyph.h>
+
+#include "kaleidoglyph/KeyAddr.h"
+
+// To enable placement new, we need to supply a global operator
+// function.
+//
+inline void* operator new (size_t, void* ptr) throw() {
+  return ptr;
+}
+
+
+namespace kaleidoglyph {
+
+// Forward declaration; we can't include the header
+class LedManager;
+
+// ============================================================================
+// This is the LED mode class. Child classes should contain an inner class
+// called "Updater", which inherits from the LedModeUpdater class.
+class LedMode {
+  friend class LedManager;
+
+ public:
+  static LedManager& manager();
+
+ protected:
+  bool isActive() const;
+
+ private:
+  static LedManager* led_manager_p_;
+
+  static void init(LedManager* led_manager_p);
+
+  byte id_;
+
+  void assignId(byte id) { id_ = id; }
+};
+
+
+// ============================================================================
+// This is the base class for an LED mode's inner Updater class, which gets
+// swapped in and out of memory.
+class LedModeUpdater {
+
+ public:
+  //LedModeUpdater(LedMode& owner) : owner_(owner) {}
+  virtual void activate() {}
+  virtual void update() {}
+  virtual void restore(KeyAddr /*k*/) const {}
+
+  // I'm considering these two helpers:
+  //LedMode& owner() const { return owner_; }
+  LedManager& manager() const { return LedMode::manager(); }
+
+ protected:
+  // The updater needs access to its "owner" (the corresponding LedMode
+  // instance).
+  //LedMode& owner_;
+};
+
+
+// ============================================================================
+// Function for factory interface to create "load" the Updater object for the
+// active LED mode class:
+template <typename _LedModeType>
+LedModeUpdater* loadLedModeUpdater(LedMode* generic_mode_p, void* updater_buffer) {
+  // Convert the generic LED mode pointer to the specific one (child class)
+  auto specific_mode_p = static_cast<_LedModeType*>(generic_mode_p);
+  // The compiler won't let us refer to `_LedModeType::Updater` without using
+  // the `typename` keyword, but that makes the followin line even more
+  // confusing, so I added this typedef.
+  typedef typename _LedModeType::Updater _UpdaterType;
+  // Create a new LedModeUpdater of the child class's actual type, and give its
+  // constructor the pointer to its owner's (enclosing) LedMode object.
+  auto updater_p = new (updater_buffer) _UpdaterType{*specific_mode_p};
+  return updater_p;
+}
+
+// Confusing function pointer typedef. This defines `LoadUpdaterFunction` as a
+// function pointer type that takes two parameters and returns an LedModeUpdater
+// pointer.
+typedef LedModeUpdater* (*LoadUpdaterFunction)(LedMode* led_mode_p, void* buffer);
+
+
+// ============================================================================
+// factory object to be stored in an array in PROGMEM, and used to create the
+// LED mode updater objects in the swap area in RAM
+struct LedModeLoader {
+  LedMode*            led_mode_p;
+  LoadUpdaterFunction loadUpdater;
+  //LedModeUpdater* (*loadUpdater)(LedMode*);
+};
+
+
+// ============================================================================
+// Size computation for largest LedModeUpdater object that can be instantiated
+
+// inner class object size template
+template <typename _LedMode>
+struct UpdaterSize {
+  static constexpr size_t value = sizeof(typename _LedMode::Updater);
+};
+
+// variadic template
+template <typename _FirstLedMode, typename... _OtherLedModes>
+struct MaxUpdaterSize {
+  static constexpr size_t first_size = UpdaterSize<_FirstLedMode>::value;
+  static constexpr size_t others_max_size =
+      MaxUpdaterSize<_OtherLedModes...>::value;
+  static constexpr size_t value =
+      (first_size > others_max_size) ? first_size : others_max_size;
+};
+
+// variadic template terminator
+template <typename _LastLedMode>
+struct MaxUpdaterSize<_LastLedMode> {
+  static constexpr size_t value = UpdaterSize<_LastLedMode>::value;
+};
+
+}  // namespace kaleidoglyph
+
+
+// ============================================================================
+// Example sketch configuration
+
+#if 0
+
+// define LED mode objects
+LedMode0 led_mode_0{};
+LedMode1 led_mode_1{};
+LedMode2 led_mode_2{};
+LedMode3 led_mode_3{};
+
+// calculate the biggest updater footprint
+constexpr byte max_updater_size = MaxUpdaterSize<decltype(led_mode_0),
+                                                 decltype(led_mode_1),
+                                                 decltype(led_mode_2),
+                                                 decltype(led_mode_3)>::value;
+// allocate memory for the active updater
+static byte updater_buffer[max_updater_size];
+
+// create array of updater factories("loaders")
+const LedModeLoader pgm_led_mode_loaders[] PROGMEM = {
+    {&led_mode_0, loadLedModeUpdater<decltype(led_mode_0), updater_buffer>},
+    {&led_mode_1, loadLedModeUpdater<decltype(led_mode_1), updater_buffer>},
+    {&led_mode_2, loadLedModeUpdater<decltype(led_mode_2), updater_buffer>},
+    {&led_mode_3, loadLedModeUpdater<decltype(led_mode_3), updater_buffer>},
+};
+
+// create LED manager
+LedManager led_manager{pgm_led_mode_loaders, updater_buffer, keyboard};
+
+#endif

--- a/src/kaleidoglyph/led/LedModeUpdater.h
+++ b/src/kaleidoglyph/led/LedModeUpdater.h
@@ -1,0 +1,60 @@
+// -*- c++ -*-
+
+#pragma once
+
+#include <Kaleidoglyph.h>
+#include "kaleidoglyph/Color.h"
+#include "kaleidoglyph/KeyAddr.h"
+#include "kaleidoglyph/led/LedMode.h"
+
+
+namespace kaleidoglyph {
+
+// This is the base class for an LED mode's inner Updater class, which gets
+// swapped in and out of memory.
+class LedModeUpdater {
+
+ public:
+  LedModeUpdater(LedMode& owner) : owner_(owner) {}
+  virtual void activate() {}
+  virtual void update() {}
+  virtual Color getKeyColor(KeyAddr k) const { return Color{0, 0, 0}; }
+  // I'm considering this one:
+  LedMode& owner() const { return owner_; }
+
+ protected:
+  LedMode& owner_;
+};
+
+// inner class object size template
+template <typename _LedMode>
+struct UpdaterSize {
+  static constexpr size_t value = sizeof(typename _LedMode::Updater);
+};
+
+// variadic template
+template <typename _FirstLedMode, typename... _OtherLedModes>
+struct MaxUpdaterSize {
+  static constexpr size_t first_size = UpdaterSize<_FirstLedMode>::value;
+  static constexpr size_t others_max_size =
+      MaxUpdaterSize<_OtherLedModes...>::value;
+  static constexpr size_t value =
+      (first_size > others_max_size) ? first_size : others_max_size;
+};
+
+// variadic template terminator
+template <typename _LastLedMode>
+struct MaxUpdaterSize<_LastLedMode> {
+  static constexpr size_t value = UpdaterSize<_LastLedMode>::value;
+};
+
+#if 0
+// This is how to use the updater size computaton helper template(s). Each
+// LedMode object should be passed as a parameter.
+constexpr byte max_updater_size =
+    MaxUpdaterSize<decltype(foo),
+                   decltype(bar),
+                   decltype(baz)>::value;
+#endif
+
+}  // namespace kaleidoglyph

--- a/src/kaleidoglyph/led/Rainbow.cpp
+++ b/src/kaleidoglyph/led/Rainbow.cpp
@@ -27,38 +27,38 @@
 
 namespace kaleidoglyph {
 
-void LedRainbowMode::update(LedController& led_controller) {
+void LedRainbowMode::Updater::update() {
 
   uint16_t current_time = Controller::scanStartTime();
   uint16_t elapsed_time = current_time - last_update_time_;
-  if (elapsed_time < update_interval_) {
+  if (elapsed_time < mode_.update_interval_) {
     return;
   }
-  last_update_time_ += update_interval_;
+  last_update_time_ += mode_.update_interval_;
   ++current_hue_;
 
-  Color current_color = hsvToRgb(current_hue_, saturation_, value_);
-  led_controller.setKeyColor(current_color);
+  Color current_color = hsvToRgb(current_hue_, mode_.saturation_, mode_.value_);
+  manager().setKeyColor(current_color);
 }
 
 
 // ---------
 
-void LedRainbowWaveMode::update(LedController& led_controller) {
+void LedRainbowWaveMode::Updater::update() {
 
   uint16_t current_time = Controller::scanStartTime();
   uint16_t elapsed_time = current_time - last_update_time_;
-  if (elapsed_time < update_interval_) {
+  if (elapsed_time < mode_.update_interval_) {
     return;
   }
-  last_update_time_ += update_interval_;
+  last_update_time_ += mode_.update_interval_;
   ++current_base_hue_;
 
   for (LedAddr led{cLedAddr::start}; led < cLedAddr::end; ++led) {
     byte key_hue_offset = 16 * (byte(led) / 4);
     byte key_hue = current_base_hue_ + key_hue_offset;
-    Color key_color = hsvToRgb(key_hue, saturation_, value_);
-    led_controller.setLedColor(led, key_color);
+    Color key_color = hsvToRgb(key_hue, mode_.saturation_, mode_.value_);
+    manager().setLedColor(led, key_color);
   }
 }
 

--- a/src/kaleidoglyph/led/Rainbow.h
+++ b/src/kaleidoglyph/led/Rainbow.h
@@ -25,7 +25,7 @@
 #include <kaleidoglyph/KeyAddr.h>
 #include <kaleidoglyph/Color.h>
 #include <kaleidoglyph/led/utils.h>
-#include "kaleidoglyph/led/LedBackgroundMode.h"
+#include "kaleidoglyph/led/LedMode.h"
 
 
 namespace kaleidoglyph {
@@ -34,42 +34,40 @@ namespace kaleidoglyph {
 // Forward declaration; we can't include the header
 class LedController;
 
-class LedRainbowMode : public LedBackgroundMode {
+class LedRainbowMode : public LedMode {
 
  public:
-
   LedRainbowMode() {}
 
-  void update(LedController& led_controller) override;
-
   void setBrightness(byte value) {
     value_ = value;
   }
-  void setInterval(byte ms) {
-    update_interval_ = ms;
+  void setUpdateInterval(byte interval) {
+    update_interval_ = interval;
   }
 
+  class Updater : public LedModeUpdater {
+   private:
+    LedRainbowMode& mode_;
+   public:
+    Updater(LedRainbowMode& mode) : mode_(mode) {}
+    void update() override;
+   private:
+    byte current_hue_{0};
+    uint16_t last_update_time_{0};
+  };
+  friend class LedRainbowMode::Updater;
 
  private:
-
-  byte current_hue_{0}; // stores 0 to 614
-
-  //byte rainbow_steps_{1};  //  number of hues we skip in a 360 range per update
-  uint16_t last_update_time_{0};
-  uint16_t update_interval_{64}; // delay between updates (ms)
-
   byte saturation_{255};
   byte value_{150};
-
+  uint16_t update_interval_{64}; // delay between updates (ms)
 };
 
-class LedRainbowWaveMode : public LedBackgroundMode {
+class LedRainbowWaveMode : public LedMode {
 
  public:
-
   LedRainbowWaveMode() {}
-
-  void update(LedController& led_controller) override;
 
   void setBrightness(byte value) {
     value_ = value;
@@ -78,18 +76,22 @@ class LedRainbowWaveMode : public LedBackgroundMode {
     update_interval_ = ms;
   }
 
+  class Updater : public LedModeUpdater {
+   private:
+    LedRainbowWaveMode& mode_;
+   public:
+    Updater(LedRainbowWaveMode& mode) : mode_(mode) {}
+    void update() override;
+   private:
+    uint16_t current_base_hue_{0};  //  stores 0 to 614
+    uint16_t last_update_time_{0};
+  };
+  friend class LedRainbowWaveMode::Updater;
 
  private:
-
-  uint16_t current_base_hue_{0};  //  stores 0 to 614
-
-  //uint8_t wave_steps_{1};  //  number of hues we skip in a 360 range per update
-  uint16_t last_update_time_{0};
-  uint16_t update_interval_{64}; // delay between updates (ms)
-
   byte saturation_{255};
   byte value_{150};
-
+  uint16_t update_interval_{64}; // delay between updates (ms)
 };
 
 //} // namespace led {

--- a/src/kaleidoglyph/led/SolidColor.h
+++ b/src/kaleidoglyph/led/SolidColor.h
@@ -6,35 +6,49 @@
 
 #include <kaleidoglyph/KeyAddr.h>
 #include <kaleidoglyph/Color.h>
+#include <kaleidoglyph/led/LedMode.h>
 
 
 namespace kaleidoglyph {
-//namespace led {
 
 // Forward declaration; we can't include the header
 class LedController;
 
-class LedSolidColorMode : public LedBackgroundMode {
+class LedSolidColorMode : public LedMode {
 
  public:
+  LedSolidColorMode()
+      : background_color_({0, 0, 0}) {}
 
   LedSolidColorMode(Color background_color)
       : background_color_(background_color) {}
 
-  void activate(LedController& led_controller) override {
-    led_controller.setKeyColor(background_color_);
-  }
+  Color getColor() { return background_color_; }
 
-  Color getKeyColor(KeyAddr /*k*/) const override {
-    return background_color_;
-  }
+  class Updater : public LedModeUpdater {
+   private:
+    // we need a pointer of the LedMode's specific type.
+    // LedSolidColorMode& owner() const {
+    //   return *(static_cast<LedSolidColorMode*>(&owner_));
+    // }
+    LedSolidColorMode& mode_;
 
+   public:
+    Updater(LedSolidColorMode& mode) : mode_(mode) {}
+    void activate() override {
+      LedMode::manager().setKeyColor(mode_.getColor());
+    }
+
+    // This mode doesn't do any updating, so it needs this to restore a key's
+    // color after a foreground override comes to an end.
+    void restore(KeyAddr k) const override {
+      LedMode::manager().setKeyColor(k, mode_.getColor());
+    }
+  };
 
  private:
-
   Color background_color_;
 
 };
 
-//} // namespace led {
 } // namespace kaleidoglyph {

--- a/src/kaleidoglyph/utils.h
+++ b/src/kaleidoglyph/utils.h
@@ -4,6 +4,8 @@
 
 #include <Arduino.h>
 
+#include <assert.h>
+
 namespace kaleidoglyph {
 
 // Return the number of `UnitType` units required to store `n` bits. Both `UnitType` &
@@ -106,6 +108,41 @@ _Type readFromProgmem(_Type const & pgm_object) {
   _Type object;
   memcpy_P(&object, &pgm_object, sizeof(object));
   return object;
+}
+
+// This might not be as useful as I want if I can't figure out how to make the
+// event handlers be a template class whose member's array size is determined by
+// the constructor.
+template <typename _Type, byte _array_length>
+void loadFromProgmemArray(_Type& dest,
+                          _Type (&pgm_array)[_array_length],
+                          byte index) {
+  assert(index < _array_length);
+
+  memcpy_P(&dest, &(pgm_array[index]), sizeof(dest));
+}
+
+template <typename _Type, byte _array_length>
+_Type readFromProgmemArray(_Type const (&pgm_array)[_array_length],
+                           byte index) {
+  assert(index < _array_length);
+  _Type object;
+  memcpy_P(&object, &(pgm_array[index]), sizeof(object));
+  return object;
+}
+
+template <typename _Type, byte _array_length>
+void loadFromProgmemArray(_Type& dest,
+                          _Type* pgm_array,
+                          byte index) {
+  assert(index < _array_length);
+
+  // To emphasize the point that we're not accessing `pgm_array[index]` (which
+  // would get us something in RAM instead of PROGMEM), we do pointer arithmetic
+  // instead.
+  _Type* pgm_entry_p = pgm_array + index;
+
+  memcpy_P(&dest, pgm_entry_p, sizeof(dest));
 }
 
 } // namespace kaleidoglyph {


### PR DESCRIPTION
This is a port of the LED mode changes made to Kaleidoscope, without much of the complexity there. I have chosen to eschew using templates in favor of other pre-build techniques for generating the sketch code (as yet unwritten). This version is now working, though with the limited LED modes I've implemented so far, it doesn't actually save any RAM (and uses ~400 extra bytes of PROGMEM). It's possible I will decide against using it in the end, but it is now working and I'm fairly happy with the design. If I ever port some of the fancier LED modes from Kaleidoscope (e.g. Wavepool, Matrix), this should save a lot of RAM. On the other hand, the savings of RAM will be of little importance on the newer keyboards with bigger MCUs.